### PR TITLE
deployment fix srv-module

### DIFF
--- a/mta.yaml
+++ b/mta.yaml
@@ -146,12 +146,6 @@ parameters:
   appname: unique-0b12e7ad
 build-parameters:
   before-all:
-<<<<<<< HEAD
-  - builder: custom
-    commands:
-    - npx -p @sap/cds-dk cds build --production
-=======
     - builder: custom
       commands:
         - npx -p @sap/cds-dk cds build --production
->>>>>>> 85de2bd (cds build config in root package.json was wrong)

--- a/mta.yaml
+++ b/mta.yaml
@@ -3,149 +3,155 @@ ID: MyHANAApp
 description: A simple CAP project.
 version: 1.0.0
 modules:
-- name: MyHANAApp-srv
-  type: nodejs
-  path: srv/gen/srv
-  requires:
-  - name: MyHANAApp-db
-  - name: uaa_MyHANAApp
-  provides:
-  - name: srv-api
-    properties:
-      srv-url: ${default-url}
-  parameters:
-    host: ${appname}
-    buildpack: nodejs_buildpack
-  build-parameters:
-    ignore: [".env", "./node_modules"]
-    builder: npm-ci
-- name: MyHANAApp-db-deployer
-  type: hdb
-  path: db
-  requires:
-  - name: MyHANAApp-db
-    properties:
-      TARGET_CONTAINER: ~{hdi-container-name}
-  - name: cross-container-service-1
-    group: SERVICE_REPLACEMENTS
-    properties:
-      key: ServiceName_1
-      service: ~{the-service-name}
-  parameters:
-    ignore: [".env", "./node_modules"]
-    buildpack: nodejs_buildpack
-- name: MyHANAApp-destination-content
-  type: com.sap.application.content
-  requires:
-  - name: MyHANAApp-destination-service
-    parameters:
-      content-target: true
-  - name: MyHANAApp_html_repo_host
-    parameters:
-      service-key:
-        name: MyHANAApp_html_repo_host-key
-  - name: uaa_MyHANAApp
-    parameters:
-      service-key:
-        name: uaa_MyHANAApp-key
-  parameters:
-    content:
-      instance:
-        destinations:
-        - Name: hana_app_MyHANAApp_html_repo_host
-          ServiceInstanceName: MyHANAApp-html5-app-host-service
-          ServiceKeyName: MyHANAApp_html_repo_host-key
-          sap.cloud.service: hana.app
-        - Authentication: OAuth2UserTokenExchange
-          Name: hana_app_uaa_MyHANAApp
-          ServiceInstanceName: MyHANAApp-xsuaa-service
-          ServiceKeyName: uaa_MyHANAApp-key
-          sap.cloud.service: hana.app
-        existing_destinations_policy: ignore
-  build-parameters:
-    no-source: true
-- name: MyHANAApp-app-content
-  type: com.sap.application.content
-  path: .
-  requires:
-  - name: MyHANAApp_html_repo_host
-    parameters:
-      content-target: true
-  build-parameters:
-    build-result: resources
+  - name: MyHANAApp-srv
+    type: nodejs
+    path: gen/srv
     requires:
-    - artifacts:
-      - frontend.zip
-      name: frontend
-      target-path: resources/
-- name: frontend
-  type: html5
-  path: app/frontend
-  build-parameters:
-    build-result: dist
-    builder: custom
-    commands:
-    - npm install
-    - npm run build:cf
-    supported-platforms: []
-resources:
-- name: MyHANAApp-db
-  type: com.sap.xs.hdi-container
-  parameters:
-    service: hana
-    service-plan: hdi-shared
-  properties:
-    hdi-container-name: ${service-name}
-- name: cross-container-service-1
-  type: org.cloudfoundry.existing-service
-  parameters:
-    service-name: MyHANAApp-hdiMyHANAApp-db-deployer-ws-4dj97
-  properties:
-    the-service-name: ${service-name}
-- name: MyHANAApp-destination-service
-  type: org.cloudfoundry.managed-service
-  parameters:
-    config:
-      HTML5Runtime_enabled: true
-      init_data:
+      - name: MyHANAApp-db
+      - name: uaa_MyHANAApp
+    provides:
+      - name: srv-api
+        properties:
+          srv-url: ${default-url}
+    parameters:
+      host: ${appname}
+      buildpack: nodejs_buildpack
+    build-parameters:
+      ignore: [".env", "./node_modules"]
+      builder: npm-ci
+  - name: MyHANAApp-db-deployer
+    type: hdb
+    path: db
+    requires:
+      - name: MyHANAApp-db
+        properties:
+          TARGET_CONTAINER: ~{hdi-container-name}
+      - name: cross-container-service-1
+        group: SERVICE_REPLACEMENTS
+        properties:
+          key: ServiceName_1
+          service: ~{the-service-name}
+    parameters:
+      ignore: [".env", "./node_modules"]
+      buildpack: nodejs_buildpack
+  - name: MyHANAApp-destination-content
+    type: com.sap.application.content
+    requires:
+      - name: MyHANAApp-destination-service
+        parameters:
+          content-target: true
+      - name: MyHANAApp_html_repo_host
+        parameters:
+          service-key:
+            name: MyHANAApp_html_repo_host-key
+      - name: uaa_MyHANAApp
+        parameters:
+          service-key:
+            name: uaa_MyHANAApp-key
+    parameters:
+      content:
         instance:
           destinations:
-          - Authentication: NoAuthentication
-            Name: ui5
-            ProxyType: Internet
-            Type: HTTP
-            URL: https://ui5.sap.com
-          - Name: hana-app-api
-            Authentication: NoAuthentication
-            ProxyType: Internet
-            HTML5.ForwardAuthToken: true
-            HTML5.DynamicDestination: true
-            Type: HTTP
-            URL: https://${appname}.${default-domain}
-          existing_destinations_policy: update
-      version: 1.0.0
-    service: destination
-    service-name: MyHANAApp-destination-service
-    service-plan: lite
-- name: MyHANAApp_html_repo_host
-  type: org.cloudfoundry.managed-service
-  parameters:
-    service: html5-apps-repo
-    service-name: MyHANAApp-html5-app-host-service
-    service-plan: app-host
-- name: uaa_MyHANAApp
-  type: org.cloudfoundry.managed-service
-  parameters:
-    path: ./xs-security.json
-    service: xsuaa
-    service-name: MyHANAApp-xsuaa-service
-    service-plan: application
+            - Name: hana_app_MyHANAApp_html_repo_host
+              ServiceInstanceName: MyHANAApp-html5-app-host-service
+              ServiceKeyName: MyHANAApp_html_repo_host-key
+              sap.cloud.service: hana.app
+            - Authentication: OAuth2UserTokenExchange
+              Name: hana_app_uaa_MyHANAApp
+              ServiceInstanceName: MyHANAApp-xsuaa-service
+              ServiceKeyName: uaa_MyHANAApp-key
+              sap.cloud.service: hana.app
+          existing_destinations_policy: ignore
+    build-parameters:
+      no-source: true
+  - name: MyHANAApp-app-content
+    type: com.sap.application.content
+    path: .
+    requires:
+      - name: MyHANAApp_html_repo_host
+        parameters:
+          content-target: true
+    build-parameters:
+      build-result: resources
+      requires:
+        - artifacts:
+            - frontend.zip
+          name: frontend
+          target-path: resources/
+  - name: frontend
+    type: html5
+    path: app/frontend
+    build-parameters:
+      build-result: dist
+      builder: custom
+      commands:
+        - npm install
+        - npm run build:cf
+      supported-platforms: []
+resources:
+  - name: MyHANAApp-db
+    type: com.sap.xs.hdi-container
+    parameters:
+      service: hana
+      service-plan: hdi-shared
+    properties:
+      hdi-container-name: ${service-name}
+  - name: cross-container-service-1
+    type: org.cloudfoundry.existing-service
+    parameters:
+      service-name: MyHANAApp-hdiMyHANAApp-db-deployer-ws-4dj97
+    properties:
+      the-service-name: ${service-name}
+  - name: MyHANAApp-destination-service
+    type: org.cloudfoundry.managed-service
+    parameters:
+      config:
+        HTML5Runtime_enabled: true
+        init_data:
+          instance:
+            destinations:
+              - Authentication: NoAuthentication
+                Name: ui5
+                ProxyType: Internet
+                Type: HTTP
+                URL: https://ui5.sap.com
+              - Name: hana-app-api
+                Authentication: NoAuthentication
+                ProxyType: Internet
+                HTML5.ForwardAuthToken: true
+                HTML5.DynamicDestination: true
+                Type: HTTP
+                URL: https://${appname}.${default-domain}
+            existing_destinations_policy: update
+        version: 1.0.0
+      service: destination
+      service-name: MyHANAApp-destination-service
+      service-plan: lite
+  - name: MyHANAApp_html_repo_host
+    type: org.cloudfoundry.managed-service
+    parameters:
+      service: html5-apps-repo
+      service-name: MyHANAApp-html5-app-host-service
+      service-plan: app-host
+  - name: uaa_MyHANAApp
+    type: org.cloudfoundry.managed-service
+    parameters:
+      path: ./xs-security.json
+      service: xsuaa
+      service-name: MyHANAApp-xsuaa-service
+      service-plan: application
 parameters:
   deploy_mode: html5-repo
   enable-parallel-deployments: true
   appname: unique-0b12e7ad
 build-parameters:
   before-all:
+<<<<<<< HEAD
   - builder: custom
     commands:
     - npx -p @sap/cds-dk cds build --production
+=======
+    - builder: custom
+      commands:
+        - npx -p @sap/cds-dk cds build --production
+>>>>>>> 85de2bd (cds build config in root package.json was wrong)

--- a/package.json
+++ b/package.json
@@ -48,14 +48,19 @@
     },
     "cds": {
         "build": {
-            "target": "."
-        },
-        "hana": {
-            "deploy-format": "hdbtable"
+            "tasks": [
+                {
+                    "for": "hana",
+                    "dest": "../db"
+                },
+                {
+                    "for": "node-cf"
+                }
+            ]
         },
         "requires": {
             "db": {
-                "kind": "hana"
+                "kind": "hana-cloud"
             }
         }
     },

--- a/srv/package.json
+++ b/srv/package.json
@@ -14,34 +14,9 @@
         "passport": "^0.4.1"
     },
     "scripts": {
-<<<<<<< HEAD
-        "start": "cds serve srv/gen/srv/csn.json"
-    },
-    "engines": {
-        "node": "14.X"
-    },
-    "cds": {
-        "build": {
-            "target": "."
-        },
-        "hana": {
-            "deploy-format": "hdbtable"
-        },
-        "requires": {
-            "db": {
-                "kind": "hana"
-            },
-            "uaa": {
-                "kind": "xsuaa"
-            }
-        }
-    }
-}
-=======
         "start": "cds serve srv/csn.json"
     },
     "engines": {
         "node": "14.X"
     }
 }
->>>>>>> 85de2bd (cds build config in root package.json was wrong)

--- a/srv/package.json
+++ b/srv/package.json
@@ -14,6 +14,7 @@
         "passport": "^0.4.1"
     },
     "scripts": {
+<<<<<<< HEAD
         "start": "cds serve srv/gen/srv/csn.json"
     },
     "engines": {
@@ -36,3 +37,11 @@
         }
     }
 }
+=======
+        "start": "cds serve srv/csn.json"
+    },
+    "engines": {
+        "node": "14.X"
+    }
+}
+>>>>>>> 85de2bd (cds build config in root package.json was wrong)


### PR DESCRIPTION
Hey Matthias, 

the only thing you have missed was probably https://developers.sap.com/tutorials/hana-cloud-cap-create-project.html - Step 5 where cds gets the configuration for the build process. (where the gen/ directory will end up and what needs to be built) 

the path in the mta.yaml was entirely right from the beginning: 


```
modules:
  - name: MyHANAApp-srv
    type: nodejs
    path: gen/srv
```

and the srv/package.json start command was also right: 

```
    "scripts": {
        "start": "cds serve srv/csn.json"
    },
```
